### PR TITLE
Make isHomepage property private

### DIFF
--- a/src/Entity/Product.php
+++ b/src/Entity/Product.php
@@ -79,13 +79,10 @@ class Product
     #[ORM\ManyToOne(inversedBy: 'products')]
     private ?Category $category = null;
 
+    //! ** isHomepage ** !//
+    //* -> Indique si le produit doit apparaître sur la page d'accueil.
     #[ORM\Column(nullable: true)]
-    public ?bool $isHomepage = null;
-        /*
-            - #[ORM\ManyToOne(...)] : Définit une relation ManyToOne avec l’entité Category.
-            - inversedBy: 'products' : Indique que la relation inverse est définie par la propriété products dans l’entité Category.
-            - private ?Category $category = null : Propriété pour stocker la catégorie à laquelle appartient le produit.
-        */
+    private ?bool $isHomepage = null;
 
     /*
     ************************************************************


### PR DESCRIPTION
## Summary
- restrict `Product::$isHomepage` visibility to private
- document homepage flag with comments and Doctrine column mapping

## Testing
- `php -d detect_unicode=0 bin/phpunit` *(fails: Unable to find the `simple-phpunit.php` script in `vendor/symfony/phpunit-bridge/bin/`)*
- `composer install` *(fails: requires GitHub token to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_689f2f04a15c8321ad44655627abe66b